### PR TITLE
Build image with go dependency from private repo

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y openssh-server
 WORKDIR /app
 
 # Creating user shinto (same as host) with home directory
-# For avoiding permission issues for src code in host and container
+# For avoiding permission issues for files created in container
 RUN groupadd -g 1001 shinto
 RUN useradd --create-home --shell /bin/bash -u 1001 -g 1001 shinto
 RUN usermod -aG sudo shinto
@@ -23,7 +23,7 @@ ENV GOPATH=/home/shinto/go
 # This only works with root user
 COPY go.* .
 RUN --mount=type=ssh \
-    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/home/shinto/go/pkg/mod \
     go mod download
 
 # Change owner of the GOPATH directory

--- a/README.md
+++ b/README.md
@@ -1,5 +1,44 @@
 # Sample Golang project using private repo
 
-This project uses a helloworld library hosted as private repo.
+This project uses a `helloworld` library hosted as private repo.
 
-I have used docker's buildkit feature to mount host ssh while building image.
+Note: If you are trying this out you will have to change the dependency to your own private repo.
+
+# Goals
+    * Have a development environment using docker
+    * Build image which download dependency from a private github repo
+
+Docker's buildkit provides `--mount=type=ssh` to mount host's ssh settings onto the intermediary
+containers created while building the image. This allows downloading go dependencies from private
+repos.
+
+Also I have made use of other buildkit features to improve caching and speed of the build process.
+
+# How to run
+
+## Development environment
+Building development environment image
+`TAG=<tag> ENV=dev make build`
+
+Edit `image` field in docker-compose.yaml
+`image: helloworld:<tag>`
+    
+Spin up the dev container:
+`docker-compose up -d`
+
+Now you can `docker exec --user <your user> app bash` and run/build your app, etc.
+
+Note: You have to edit `Dockerfile.dev` and add your user instead of `shinto`. I create
+user `shinto` in the image so that there are no file permission conflicts 
+in host and the container.
+
+## Building image for deployment
+Run
+```
+TAG=<tag> ENV=build make build
+
+docker run -it --rm --name sample helloworld:<TAG>
+```
+
+# Demo
+[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/MZ0cwjbuhAA/0.jpg)](https://www.youtube.com/watch?v=MZ0cwjbuhAA)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,6 @@ version: '3'
 
 services:
   app:
-    # build:
-    #   context: . 
-    #   dockerfile: Dockerfile.dev
     image: helloworld:ssh.1.5
     command: ["tail", "-f", "/dev/null"]
     ports:
@@ -12,7 +9,6 @@ services:
     volumes:
       - .:/app
       - ~/.ssh:/home/shinto/.ssh
-    user: "${UID}:${GID}"
     networks: 
       - backend
 


### PR DESCRIPTION
Updated README with necessary steps to spin up the dev container.

The repo currently has two dockerfiles: one for dev environment and one for deployment.

I create a user in the dev environment image to avoid file permission conflicts.

Curiously I didn't have to set GOPRIVATE env var to do this to download private repo dependencies!
